### PR TITLE
ARIA-433 Add a name for the STUB_TYPE Enum

### DIFF
--- a/aria/modeling/orchestration.py
+++ b/aria/modeling/orchestration.py
@@ -426,7 +426,7 @@ class TaskBase(mixins.ModelMixin):
     _api_id = Column(String)
     _executor = Column(PickleType)
     _context_cls = Column(PickleType)
-    _stub_type = Column(Enum(*STUB_TYPES))
+    _stub_type = Column(Enum(*STUB_TYPES, name='stub_type'))
 
     @property
     def actor(self):


### PR DESCRIPTION
Enums without a name are invalid in postgresql.
This is the only enum that doesn't have a name.